### PR TITLE
Show all packages ever proposed by a user on the user's profile page.

### DIFF
--- a/include/pear-database-user.php
+++ b/include/pear-database-user.php
@@ -143,6 +143,18 @@ class user
         return $dbh->getAll($query, array($user, SITE));
     }
 
+    static function getProposals($user)
+    {
+        global $dbh;
+
+        $query = 'SELECT id, pkg_name, status,'
+            . ' draft_date, proposal_date, vote_date'
+            . ' FROM package_proposals'
+            . ' WHERE user_handle = ? ORDER BY draft_date ASC';
+
+        return $dbh->getAll($query, array($user));
+    }
+
     static function info($user, $field = null, $registered = true, $hidePassword = true)
     {
         global $dbh;

--- a/public_html/account-info.php
+++ b/public_html/account-info.php
@@ -288,6 +288,33 @@ foreach ($notes as $nid => $data) {
 ?>
 
    </ul>
+<?php
+$proposals = user::getProposals($handle);
+if (count($proposals) > 0) {
+    echo "<h4>Package Proposals</h4>";
+}
+?>
+   <ul>
+<?php
+foreach ($proposals as $nid => $data) {
+    switch($data['status']) {
+        case 'draft':
+        $when = $data['draft_date'];
+        break;
+        case 'finished':
+        $when = $data['vote_date'];
+        default:
+        $when = $data['proposal_date'];
+    }
+    echo ' <li>' . "\n";
+    echo '<a href="/pepr/pepr-proposal-show.php?id='. $data['id'].'">' . $data['pkg_name'] . '</a>';
+    echo ' (' . $data['status'] . ', '. format_date(strtotime($when), 'Y-m-d') . ')';
+    echo "\n </li>\n";
+}
+
+?>
+
+   </ul>
   </td>
  </tr>
 <?php

--- a/public_html/account-info.php
+++ b/public_html/account-info.php
@@ -297,18 +297,24 @@ if (count($proposals) > 0) {
    <ul>
 <?php
 foreach ($proposals as $nid => $data) {
+    $cStatus = $data['status'];
     switch($data['status']) {
         case 'draft':
-        $when = $data['draft_date'];
-        break;
+            $when = $data['draft_date'];
+            break;
+        case 'proposal':
+            $cStatus = 'proposed';
+            $when = $data['proposal_date'];
+            break;
         case 'finished':
-        $when = $data['vote_date'];
+            $when = $data['vote_date'];
+            break;
         default:
-        $when = $data['proposal_date'];
+            $when = $data['proposal_date'];
     }
     echo ' <li>' . "\n";
     echo '<a href="/pepr/pepr-proposal-show.php?id='. $data['id'].'">' . $data['pkg_name'] . '</a>';
-    echo ' (' . $data['status'] . ', '. format_date(strtotime($when), 'Y-m-d') . ')';
+    echo ' (' . $cStatus . ', '. format_date(strtotime($when), 'Y-m-d') . ')';
     echo "\n </li>\n";
 }
 


### PR DESCRIPTION
These are listed in a new 'Package proposals' section, underneath the 'History' section.

The rationale behind this is primarily to help bring attention to proposals that a user might have open, that other members of the PEAR community might not already be aware of.

There is a side-effect that it will also indicate whether an account was created and then just forgotten about with no packages ever proposed or worked on.