### PR TITLE
Add missing space between HTML attributes

### DIFF
--- a/public_html/bugs/report.php
+++ b/public_html/bugs/report.php
@@ -733,7 +733,7 @@ if (auth_check('pear.dev')) {
    </p>
   </th>
   <td class="form-input">
-   <textarea cols="60" rows="8" name="in[repcode]" id="in[repcode]"wrap="no"><?php echo clean($_POST['in']['repcode']); ?></textarea>
+   <textarea cols="60" rows="8" name="in[repcode]" id="in[repcode]" wrap="no"><?php echo clean($_POST['in']['repcode']); ?></textarea>
   </td>
  </tr>
  <tr>


### PR DESCRIPTION
Note that ``wrap=no`` and ``wrap="physical"`` used in textareas in this page are weird. The spec defines only 2 valid values for this attribute: ``soft`` and ``hard``